### PR TITLE
Allow users to pass an explicit date

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,14 +18,9 @@ inputs:
     description: Configuration for the build
     required: true
     type: string
-  date-format:
-    description:
-    default: '%y%m%d-%H%M%S'
-    type: string
-    required: false
   format:
     description: Format to use for the build artifact
-    default: '{project}-%ad-%h-{shortname}+{platform}+{configuration}+{branch}.zip'
+    default: '{project}-{datetime}-%h-{shortname}+{platform}+{configuration}+{branch}.zip'
     type: string
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,13 @@ inputs:
     description: Configuration for the build
     required: true
     type: string
+  date:
+    description: |
+      Date to use for the build (will use git log if not set)
+
+      Use a UTC timestamp in the format '2011-04-14T16:00:49ZZ' (Note the double ZZ)
+    required: false
+    type: string
   format:
     description: Format to use for the build artifact
     default: '{project}-{datetime}-%h-{shortname}+{platform}+{configuration}+{branch}.zip'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1731,6 +1731,20 @@ function execGit(args, silent = true) {
         return result;
     });
 }
+function getGitDate() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const args = [
+            'log',
+            '-1',
+            `--date=unix`,
+            `--pretty=%ad`,
+        ];
+        const result = yield execGit(args);
+        const unixTimestamp = parseInt(result.stdout.trim());
+        console.log(`Git date: ${unixTimestamp}`);
+        return new Date(1000 * unixTimestamp);
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -1744,24 +1758,25 @@ function run() {
                 throw new Error("No build-configuration supplied");
             }
             const branch = (core.getInput('branch-name') || process.env.GITHUB_REF_NAME).toLowerCase();
-            const dateFormat = core.getInput('date-format');
             const logFormat = core.getInput('format');
+            const logDate = yield getGitDate();
+            console.log(`Date: ${logDate}`);
+            const logDateYear = (logDate.getUTCFullYear() % 100).toString().padStart(2, '0');
+            const logDateMonth = (logDate.getUTCMonth() + 1).toString().padStart(2, '0');
+            const logDateDate = logDate.getUTCDate().toString().padStart(2, '0');
+            const logDateHour = logDate.getUTCHours().toString().padStart(2, '0');
+            const logDateMinute = logDate.getUTCMinutes().toString().padStart(2, '0');
+            const logDateSecond = logDate.getUTCSeconds().toString().padStart(2, '0');
+            const longDate = `${logDateYear}${logDateMonth}${logDateDate}-${logDateHour}${logDateMinute}${logDateSecond}`;
+            const shortDate = `${logDateMonth}${logDateDate}`;
             const args = [
                 'log',
                 '-1',
-                `--date=format-local:${dateFormat}`,
                 `--pretty=${logFormat}`,
             ];
             const result = yield execGit(args);
             var templateName = result.stdout.trim();
-            // get short date format
-            const shortDateArgs = [
-                'log',
-                '-1',
-                '--date=format-local:%m%d',
-                '--pretty=%ad',
-            ];
-            const shortDate = (yield execGit(shortDateArgs)).stdout.trim();
+            templateName = templateName.replace('{datetime}', longDate);
             templateName = templateName.replace('{project}', projectName).replace('{branch}', branch);
             const shortName = shortDate + wordlist.generateAdjectiveNoun(templateName);
             core.setOutput('short', shortName);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1745,7 +1745,19 @@ function getGitDate() {
         return new Date(1000 * unixTimestamp);
     });
 }
+function parseCustomDate() {
+    const raw = core.getInput('date');
+    if (!raw) {
+        return undefined;
+    }
+    // Need to have a double ZZ prefix to keep GitHub from interpolating the data
+    if (!raw.endsWith('ZZ')) {
+        throw new Error("Custom date input MUST end with ZZ to prevent GitHub from interpolating time zones");
+    }
+    return new Date(raw.substring(0, raw.length - 1));
+}
 function run() {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             // get project name
@@ -1759,8 +1771,7 @@ function run() {
             }
             const branch = (core.getInput('branch-name') || process.env.GITHUB_REF_NAME).toLowerCase();
             const logFormat = core.getInput('format');
-            const logDate = yield getGitDate();
-            console.log(`Date: ${logDate}`);
+            const logDate = (_a = parseCustomDate()) !== null && _a !== void 0 ? _a : yield getGitDate();
             const logDateYear = (logDate.getUTCFullYear() % 100).toString().padStart(2, '0');
             const logDateMonth = (logDate.getUTCMonth() + 1).toString().padStart(2, '0');
             const logDateDate = logDate.getUTCDate().toString().padStart(2, '0');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",
-        "@actions/io": "^1.0.1",
-        "@types/sha1": "^1.1.3"
+        "@actions/io": "^1.0.1"
       },
       "devDependencies": {
         "@types/node": "^18.8.5",
@@ -52,15 +51,8 @@
     "node_modules/@types/node": {
       "version": "18.8.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
-    },
-    "node_modules/@types/sha1": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/sha1/-/sha1-1.1.3.tgz",
-      "integrity": "sha512-bXfx/6xrPu1l6pLItGRMPX00lhnJavpj2qiQeLHflXvL2Ix97aC8FTF2/pQoqukRzcCwKyN3csZvOLzamIoaSA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
+      "dev": true
     },
     "node_modules/@zeit/ncc": {
       "version": "0.22.3",
@@ -136,15 +128,8 @@
     "@types/node": {
       "version": "18.8.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
-    },
-    "@types/sha1": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/sha1/-/sha1-1.1.3.tgz",
-      "integrity": "sha512-bXfx/6xrPu1l6pLItGRMPX00lhnJavpj2qiQeLHflXvL2Ix97aC8FTF2/pQoqukRzcCwKyN3csZvOLzamIoaSA==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
+      "dev": true
     },
     "@zeit/ncc": {
       "version": "0.22.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,20 @@ async function getGitDate() : Promise<Date> {
     return new Date(1000 * unixTimestamp)
 }
 
+function parseCustomDate() : Date|undefined {
+  const raw = core.getInput('date')
+  if (!raw) {
+    return undefined
+  }
+
+  // Need to have a double ZZ prefix to keep GitHub from interpolating the data
+  if (!raw.endsWith('ZZ')) {
+    throw new Error("Custom date input MUST end with ZZ to prevent GitHub from interpolating time zones")
+  }
+
+  return new Date(raw.substring(0, raw.length - 1))
+}
+
 async function run() : Promise<void> {
 
   try {
@@ -75,7 +89,7 @@ async function run() : Promise<void> {
 
     const logFormat = core.getInput('format')
 
-    const logDate = await getGitDate()
+    const logDate = parseCustomDate() ?? await getGitDate()
     const logDateYear = (logDate.getUTCFullYear() % 100).toString().padStart(2, '0')
     const logDateMonth = (logDate.getUTCMonth() + 1).toString().padStart(2, '0')
     const logDateDate = logDate.getUTCDate().toString().padStart(2, '0')


### PR DESCRIPTION
This lets us generate a name without the need to have the actual repository cloned locally.