### PR TITLE
No longer require ZZ suffix on date strings

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -94,11 +94,7 @@ function parseCustomDate() {
     if (!raw) {
         return undefined;
     }
-    // Need to have a double ZZ prefix to keep GitHub from interpolating the data
-    if (!raw.endsWith('ZZ')) {
-        throw new Error("Custom date input MUST end with ZZ to prevent GitHub from interpolating time zones");
-    }
-    return new Date(raw.substring(0, raw.length - 1));
+    return new Date(raw);
 }
 function run() {
     var _a;

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,12 +62,7 @@ function parseCustomDate() : Date|undefined {
     return undefined
   }
 
-  // Need to have a double ZZ prefix to keep GitHub from interpolating the data
-  if (!raw.endsWith('ZZ')) {
-    throw new Error("Custom date input MUST end with ZZ to prevent GitHub from interpolating time zones")
-  }
-
-  return new Date(raw.substring(0, raw.length - 1))
+  return new Date(raw)
 }
 
 async function run() : Promise<void> {


### PR DESCRIPTION
This was working around an output issue in a separate action, and shouldn't be here